### PR TITLE
Update relevant code to Treasury pallet in the `pallet_bounty`

### DIFF
--- a/substrate/frame/bounties/src/benchmarking.rs
+++ b/substrate/frame/bounties/src/benchmarking.rs
@@ -171,27 +171,6 @@ benchmarks_instance_pallet! {
 		ensure!(!T::Currency::free_balance(&beneficiary_account).is_zero(), "Beneficiary didn't get paid");
 	}
 
-	close_bounty_proposed {
-		setup_pot_account::<T, I>();
-		let (caller, curator, fee, value, reason) = setup_bounty::<T, I>(0, 0);
-		Bounties::<T, I>::propose_bounty(RawOrigin::Signed(caller).into(), value, reason)?;
-		let bounty_id = BountyCount::<T, I>::get() - 1;
-		let approve_origin =
-			T::ApproveOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
-	}: close_bounty<T::RuntimeOrigin>(approve_origin, bounty_id)
-
-	close_bounty_active {
-		setup_pot_account::<T, I>();
-		let (curator_lookup, bounty_id) = create_bounty::<T, I>()?;
-		Treasury::<T, I>::on_initialize(BlockNumberFor::<T>::zero());
-		let bounty_id = BountyCount::<T, I>::get() - 1;
-		let approve_origin =
-			T::ApproveOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
-	}: close_bounty<T::RuntimeOrigin>(approve_origin, bounty_id)
-	verify {
-		assert_last_event::<T, I>(Event::BountyCanceled { index: bounty_id }.into())
-	}
-
 	extend_bounty_expiry {
 		setup_pot_account::<T, I>();
 		let (curator_lookup, bounty_id) = create_bounty::<T, I>()?;

--- a/substrate/frame/bounties/src/lib.rs
+++ b/substrate/frame/bounties/src/lib.rs
@@ -460,8 +460,7 @@ pub mod pallet {
 
 				let slash_curator = |curator: &T::AccountId,
 				                     curator_deposit: &mut BalanceOf<T, I>| {
-					let imbalance = T::Currency::slash_reserved(curator, *curator_deposit).0;
-					T::OnSlash::on_unbalanced(imbalance);
+					T::Currency::slash_reserved(curator, *curator_deposit).0;
 					*curator_deposit = Zero::zero();
 				};
 
@@ -713,8 +712,7 @@ pub mod pallet {
 							// The reject origin would like to cancel a proposed bounty.
 							BountyDescriptions::<T, I>::remove(bounty_id);
 							let value = bounty.bond;
-							let imbalance = T::Currency::slash_reserved(&bounty.proposer, value).0;
-							T::OnSlash::on_unbalanced(imbalance);
+							T::Currency::slash_reserved(&bounty.proposer, value).0;
 							*maybe_bounty = None;
 
 							Self::deposit_event(Event::<T, I>::BountyRejected {

--- a/substrate/frame/bounties/src/tests.rs
+++ b/substrate/frame/bounties/src/tests.rs
@@ -82,7 +82,6 @@ impl pallet_balances::Config for Test {
 	type RuntimeFreezeReason = ();
 }
 parameter_types! {
-	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub static Burn: Permill = Permill::from_percent(50);
 	pub const TreasuryPalletId: PalletId = PalletId(*b"py/trsry");
 	pub const TreasuryPalletId2: PalletId = PalletId(*b"py/trsr2");
@@ -95,13 +94,8 @@ parameter_types! {
 impl pallet_treasury::Config for Test {
 	type PalletId = TreasuryPalletId;
 	type Currency = pallet_balances::Pallet<Test>;
-	type ApproveOrigin = frame_system::EnsureRoot<u128>;
 	type RejectOrigin = frame_system::EnsureRoot<u128>;
 	type RuntimeEvent = RuntimeEvent;
-	type OnSlash = ();
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ConstU64<1>;
-	type ProposalBondMaximum = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = (); // Just gets burned.
@@ -122,13 +116,8 @@ impl pallet_treasury::Config for Test {
 impl pallet_treasury::Config<Instance1> for Test {
 	type PalletId = TreasuryPalletId2;
 	type Currency = pallet_balances::Pallet<Test>;
-	type ApproveOrigin = frame_system::EnsureRoot<u128>;
 	type RejectOrigin = frame_system::EnsureRoot<u128>;
 	type RuntimeEvent = RuntimeEvent;
-	type OnSlash = ();
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ConstU64<1>;
-	type ProposalBondMaximum = ();
 	type SpendPeriod = ConstU64<2>;
 	type Burn = Burn;
 	type BurnDestination = (); // Just gets burned.
@@ -228,55 +217,11 @@ fn minting_works() {
 }
 
 #[test]
-fn spend_proposal_takes_min_deposit() {
-	new_test_ext().execute_with(|| {
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
-		});
-		assert_eq!(Balances::free_balance(0), 99);
-		assert_eq!(Balances::reserved_balance(0), 1);
-	});
-}
-
-#[test]
-fn spend_proposal_takes_proportional_deposit() {
-	new_test_ext().execute_with(|| {
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_eq!(Balances::free_balance(0), 95);
-		assert_eq!(Balances::reserved_balance(0), 5);
-	});
-}
-
-#[test]
-fn spend_proposal_fails_when_proposer_poor() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::propose_spend(RuntimeOrigin::signed(2), 100, 3)
-			},
-			TreasuryError::InsufficientProposersBalance,
-		);
-	});
-}
-
-#[test]
 fn accepted_spend_proposal_ignored_outside_spend_period() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::root(), 100, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(1);
 		assert_eq!(Balances::free_balance(3), 0);
@@ -298,111 +243,12 @@ fn unused_pot_should_diminish() {
 }
 
 #[test]
-fn rejected_spend_proposal_ignored_on_spend_period() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-		});
-
-		<Treasury as OnInitialize<u64>>::on_initialize(2);
-		assert_eq!(Balances::free_balance(3), 0);
-		assert_eq!(Treasury::pot(), 50);
-	});
-}
-
-#[test]
-fn reject_already_rejected_spend_proposal_fails() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-		});
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-			},
-			TreasuryError::InvalidIndex
-		);
-	});
-}
-
-#[test]
-fn reject_non_existent_spend_proposal_fails() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-			},
-			pallet_treasury::Error::<Test>::InvalidIndex
-		);
-	});
-}
-
-#[test]
-fn accept_non_existent_spend_proposal_fails() {
-	new_test_ext().execute_with(|| {
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-			},
-			TreasuryError::InvalidIndex
-		);
-	});
-}
-
-#[test]
-fn accept_already_rejected_spend_proposal_fails() {
-	new_test_ext().execute_with(|| {
-		Balances::make_free_balance_be(&Treasury::account_id(), 101);
-
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::reject_proposal(RuntimeOrigin::root(), 0)
-		});
-		assert_noop!(
-			{
-				#[allow(deprecated)]
-				Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-			},
-			TreasuryError::InvalidIndex
-		);
-	});
-}
-
-#[test]
 fn accepted_spend_proposal_enacted_on_spend_period() {
 	new_test_ext().execute_with(|| {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 100, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::root(), 100, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Balances::free_balance(3), 100);
@@ -416,14 +262,7 @@ fn pot_underflow_should_not_diminish() {
 		Balances::make_free_balance_be(&Treasury::account_id(), 101);
 		assert_eq!(Treasury::pot(), 100);
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 150, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::root(), 150, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
@@ -444,26 +283,12 @@ fn treasury_account_doesnt_get_deleted() {
 		assert_eq!(Treasury::pot(), 100);
 		let treasury_balance = Balances::free_balance(&Treasury::account_id());
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), treasury_balance, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::root(), treasury_balance, 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 100); // Pot hasn't changed
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), Treasury::pot(), 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 1)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::root(), Treasury::pot(), 3));
 
 		<Treasury as OnInitialize<u64>>::on_initialize(4);
 		assert_eq!(Treasury::pot(), 0); // Pot is emptied
@@ -486,22 +311,8 @@ fn inexistent_account_works() {
 		assert_eq!(Balances::free_balance(Treasury::account_id()), 0); // Account does not exist
 		assert_eq!(Treasury::pot(), 0); // Pot is empty
 
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 99, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 0)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::propose_spend(RuntimeOrigin::signed(0), 1, 3)
-		});
-		assert_ok!({
-			#[allow(deprecated)]
-			Treasury::approve_proposal(RuntimeOrigin::root(), 1)
-		});
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::root(), 99, 3));
+		assert_ok!(Treasury::spend_local(RuntimeOrigin::root(), 1, 3));
 		<Treasury as OnInitialize<u64>>::on_initialize(2);
 		assert_eq!(Treasury::pot(), 0); // Pot hasn't changed
 		assert_eq!(Balances::free_balance(3), 0); // Balance of `3` hasn't changed


### PR DESCRIPTION
# Description
- Parent issue: https://github.com/paritytech/polkadot-sdk/pull/3820

Remove deprecated Treasury relevant code in the Bounties pallet code
- [x] Remove `T::OnSlash::on_unbalanced(imbalance)`
- [x] Remove parameter types related to the Treasury pallet
```rust
type OnSlash = ();
type ProposalBond = ProposalBond;
type ProposalBondMinimum = ConstU64<1>;
type ProposalBondMaximum = ();
```
- [x] Update benchmarks and tests
`prdoc` file will be added in the parent issue https://github.com/paritytech/polkadot-sdk/pull/3820
# Test Outcome
```
running 40 tests
test tests::__construct_runtime_integrity_test::runtime_integrity_tests ... ok
test benchmarking::bench_approve_bounty ... ok
test benchmarking::bench_propose_curator ... ok
test benchmarking::bench_award_bounty ... ok
test benchmarking::bench_accept_curator ... ok
test benchmarking::bench_unassign_curator ... ok
test benchmarking::bench_extend_bounty_expiry ... ok
test tests::accepted_spend_proposal_enacted_on_spend_period ... ok
test tests::accepted_spend_proposal_ignored_outside_spend_period ... ok
test benchmarking::bench_claim_bounty ... ok
test tests::approve_bounty_instance1_insufficient_spend_limit_errors ... ok
test tests::accept_curator_handles_different_deposit_calculations ... ok
test tests::approve_bounty_insufficient_spend_limit_errors ... ok
test tests::approve_bounty_works_second_instance ... ok
test tests::approve_bounty_works ... ok
test benchmarking::bench_propose_bounty ... ok
test tests::close_bounty_works ... ok
test tests::award_and_cancel ... ok
test tests::genesis_config_works ... ok
test tests::genesis_funding_works ... ok
test tests::claim_handles_high_fee ... ok
test tests::assign_curator_works ... ok
test tests::award_and_claim_bounty_works ... ok
test tests::expire_and_unassign ... ok
test tests::minting_works ... ok
test tests::inexistent_account_works ... ok
test tests::test_genesis_config_builds ... ok
test tests::pot_underflow_should_not_diminish ... ok
test tests::propose_bounty_works ... ok
test tests::test_migration_v4 ... ok
test tests::cancel_and_refund ... ok
test tests::propose_bounty_validation_works ... ok
test tests::treasury_account_doesnt_get_deleted ... ok
test tests::extend_expiry ... ok
test tests::unassign_curator_self ... ok
test tests::unused_pot_should_diminish ... ok
test tests::propose_curator_insufficient_spend_limit_errors ... ok
test tests::propose_curator_instance1_insufficient_spend_limit_errors ... ok
test tests::unassign_curator_works ... ok
test benchmarking::bench_spend_funds ... ok

test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s

   Doc-tests pallet_bounties

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```